### PR TITLE
Add dependencies required to render line charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 d3-min.js: node_modules
 	node_modules/.bin/smash $(shell node_modules/.bin/smash --list \
 	  d3-wrapper-start.js \
+	  node_modules/d3/src/arrays/extent.js \
 	  node_modules/d3/src/compat/index.js \
 	  node_modules/d3/src/selection/* \
 	  node_modules/d3/src/behavior/* \
@@ -8,7 +9,10 @@ d3-min.js: node_modules
 	  node_modules/d3/src/geom/polygon.js \
 	  node_modules/d3/src/scale/linear.js \
 	  node_modules/d3/src/scale/log.js \
+	  node_modules/d3/src/time/format.js \
+	  node_modules/d3/src/time/scale.js \
 	  node_modules/d3/src/transition/* \
+	  node_modules/d3/src/svg/axis.js \
 	  node_modules/d3/src/svg/line.js \
 	  node_modules/d3/src/svg/arc.js \
 	  node_modules/d3/src/event/drag.js \


### PR DESCRIPTION
## To QA
- Run `npm i` in this repo
- Run `make d3-min.js` to build d3.js and d3-min.js
- Checkout the GUI with the ISV profile charting [1]
- Replace the d3.js and d3-min.js files from this repo into your GUI branch at `jujugui/static/gui/src/app/assets/javascripts/`
- Clean and run the GUI `make clean-gui fast-babel run`
- Once running go to `http://0.0.0.0:6543/isv/:flags:/blues/` and check the chart is rendered

[1] https://github.com/juju/juju-gui/pull/1951/
